### PR TITLE
Remove prefer-object-spread from node8 config

### DIFF
--- a/config/mocha.yaml
+++ b/config/mocha.yaml
@@ -1,0 +1,14 @@
+env:
+  mocha: true
+globals:
+  sinon: false
+  chai: false
+  expect: false
+  should: false
+  assert: false
+rules:
+  no-unused-expressions: off
+  no-restricted-modules:
+    - error
+    - proxyquire
+    - rewire

--- a/config/nodejs.yaml
+++ b/config/nodejs.yaml
@@ -1,0 +1,11 @@
+env:
+  node: true,
+  es6: true
+extends:
+  - eslint:recommended
+  - ../rules/best-practices.yaml
+  - ../rules/ecmascript-6.yaml
+  - ../rules/node_js-and-commonjs.yaml
+  - ../rules/possible-errors.yaml
+  - ../rules/stylistic-issues.yaml
+  - ../rules/variables.yaml

--- a/config/nodejs10.yaml
+++ b/config/nodejs10.yaml
@@ -1,0 +1,4 @@
+extends:
+  - ./nodejs.yaml
+parserOptions:
+  ecmaVersion: 2018

--- a/config/nodejs8.yaml
+++ b/config/nodejs8.yaml
@@ -1,0 +1,6 @@
+extends:
+  - ./nodejs.yaml
+parserOptions:
+  ecmaVersion: 2017
+rules:
+  prefer-object-spread: off

--- a/node/10/main.js
+++ b/node/10/main.js
@@ -1,8 +1,1 @@
-module.exports = {
-    extends: [
-        '../main.js'
-    ],
-    parserOptions: {
-        ecmaVersion: 2018
-    }
-}
+module.exports.extends = '../../config/nodejs10.yaml'

--- a/node/10/mocha.js
+++ b/node/10/mocha.js
@@ -1,9 +1,4 @@
-module.exports = {
-    extends: [
-        '../main.js',
-        '../mocha.js'
-    ],
-    parserOptions: {
-        ecmaVersion: 2018
-    }
-}
+module.exports.extends = [
+    './main.js',
+    '../../config/mocha.yaml'
+]

--- a/node/main.js
+++ b/node/main.js
@@ -1,18 +1,1 @@
-module.exports = {
-    env: {
-        node: true,
-        es6: true
-    },
-    parserOptions: {
-        ecmaVersion: 2017
-    },
-    extends: [
-        'eslint:recommended',
-        '../rules/best-practices.yaml',
-        '../rules/ecmascript-6.yaml',
-        '../rules/node_js-and-commonjs.yaml',
-        '../rules/possible-errors.yaml',
-        '../rules/stylistic-issues.yaml',
-        '../rules/variables.yaml'
-    ]
-}
+module.exports.extends = '../config/nodejs8.yaml'

--- a/node/mocha.js
+++ b/node/mocha.js
@@ -1,23 +1,4 @@
-module.exports = {
-    env: {
-        mocha: true
-    },
-    globals: {
-        sinon: false,
-        chai: false,
-        expect: false,
-        should: false,
-        assert: false
-    },
-    extends: [
-        './main.js'
-    ],
-    rules: {
-        'no-unused-expressions': 'off',
-        'no-restricted-modules': [
-            'error',
-            'proxyquire',
-            'rewire'
-        ]
-    }
-}
+module.exports.extends = [
+    './main.js',
+    '../config/mocha.yaml'
+]

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/smartrecruiters/eslint-config",
   "files": [
+    "config",
     "node",
     "rules"
   ]


### PR DESCRIPTION
## Description
The aim is to have rules:`prefer-object-spread`: error only for node.js 10. Additionally, config for node.js 10 does not extend now config for node.js 8, mocha config for node.js 10 now extends config for node.js 10 (instead of config for node.js 8) 